### PR TITLE
Fix import for ISwapRouter

### DIFF
--- a/src/handlers/AgniSingleTickLiquidityHandlerV2.sol
+++ b/src/handlers/AgniSingleTickLiquidityHandlerV2.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 // Interfaces
 import {IAgniPool} from "../agni-v3/v3-core/contracts/interfaces/IAgniPool.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
-import {ISwapRouter} from "v3-periphery/SwapRouter.sol";
+import {ISwapRouter} from "v3-periphery/interfaces/ISwapRouter.sol";
 import {IHandler} from "../interfaces/IHandler.sol";
 import {IHook} from "../interfaces/IHook.sol";
 

--- a/src/handlers/BulletXV3SingleTickLiquidityHandlerV2.sol
+++ b/src/handlers/BulletXV3SingleTickLiquidityHandlerV2.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 // Interfaces
 import {IBulletXV3Pool} from "../bulletX-v3/v3-core/contracts/interfaces/IBulletXV3Pool.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
-import {ISwapRouter} from "v3-periphery/SwapRouter.sol";
+import {ISwapRouter} from "v3-periphery/interfaces/ISwapRouter.sol";
 import {IHandler} from "../interfaces/IHandler.sol";
 import {IHook} from "../interfaces/IHook.sol";
 

--- a/src/handlers/ButterSingleTickLiquidityHandlerV2.sol
+++ b/src/handlers/ButterSingleTickLiquidityHandlerV2.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 // Interfaces
 import {IButterPool} from "../butter-v3/v3-core/contracts/interfaces/IButterPool.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
-import {ISwapRouter} from "v3-periphery/SwapRouter.sol";
+import {ISwapRouter} from "v3-periphery/interfaces/ISwapRouter.sol";
 import {IHandler} from "../interfaces/IHandler.sol";
 import {IHook} from "../interfaces/IHook.sol";
 

--- a/src/handlers/FusionXV3SingleTickLiquidityHandlerV2.sol
+++ b/src/handlers/FusionXV3SingleTickLiquidityHandlerV2.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 // Interfaces
 import {IFusionXV3Pool} from "../fusionX-v3/v3-core/contracts/interfaces/IFusionXV3Pool.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
-import {ISwapRouter} from "v3-periphery/SwapRouter.sol";
+import {ISwapRouter} from "v3-periphery/interfaces/ISwapRouter.sol";
 import {IHandler} from "../interfaces/IHandler.sol";
 import {IHook} from "../interfaces/IHook.sol";
 

--- a/src/handlers/KodiakV3SingleTickLiquidityHandlerV2.sol
+++ b/src/handlers/KodiakV3SingleTickLiquidityHandlerV2.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 // Interfaces
 import {IUniswapV3Pool} from "../kodiak-v3/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
-import {ISwapRouter} from "v3-periphery/SwapRouter.sol";
+import {ISwapRouter} from "v3-periphery/interfaces/ISwapRouter.sol";
 import {IHandler} from "../interfaces/IHandler.sol";
 import {IHook} from "../interfaces/IHook.sol";
 

--- a/src/handlers/PancakeV3SingleTickLiquidityHandlerV2.sol
+++ b/src/handlers/PancakeV3SingleTickLiquidityHandlerV2.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 // Interfaces
 import {IPancakeV3Pool} from "../pancake-v3/v3-core/contracts/interfaces/IPancakeV3Pool.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
-import {ISwapRouter} from "v3-periphery/SwapRouter.sol";
+import {ISwapRouter} from "v3-periphery/interfaces/ISwapRouter.sol";
 import {IHandler} from "../interfaces/IHandler.sol";
 import {IHook} from "../interfaces/IHook.sol";
 

--- a/src/handlers/PancakeV3SingleTickLiquidityHandlerV3.sol
+++ b/src/handlers/PancakeV3SingleTickLiquidityHandlerV3.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 // Interfaces
 import {IPancakeV3Pool} from "../pancake-v3/v3-core/contracts/interfaces/IPancakeV3Pool.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
-import {ISwapRouter} from "v3-periphery/SwapRouter.sol";
+import {ISwapRouter} from "v3-periphery/interfaces/ISwapRouter.sol";
 import {IHandler} from "../interfaces/IHandler.sol";
 import {IHook} from "../interfaces/IHook.sol";
 
@@ -179,7 +179,7 @@ contract PancakeV3SingleTickLiquidityHandlerV3 is ERC6909, IHandler, Pausable, A
         onlyWhitelisted();
 
         MintPositionParams memory _params = abi.decode(_mintPositionData, (MintPositionParams));
-        
+
         if (!whitelistedPools[address(_params.pool)]) revert PancakeV3SingleTickLiquidityHandlerV3__NotWhitelistedPool();
 
         uint256 tokenId = _getHandlerIdentifier(_params.pool, _params.hook, _params.tickLower, _params.tickUpper);

--- a/src/handlers/SushiV3SingleTickLiquidityHandlerV2.sol
+++ b/src/handlers/SushiV3SingleTickLiquidityHandlerV2.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 // Interfaces
 import {IUniswapV3Pool} from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
-import {ISwapRouter} from "v3-periphery/SwapRouter.sol";
+import {ISwapRouter} from "v3-periphery/interfaces/ISwapRouter.sol";
 import {IHandler} from "../interfaces/IHandler.sol";
 import {IHook} from "../interfaces/IHook.sol";
 

--- a/src/handlers/SushiV3SingleTickLiquidityHandlerV3.sol
+++ b/src/handlers/SushiV3SingleTickLiquidityHandlerV3.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 // Interfaces
 import {IUniswapV3Pool} from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
-import {ISwapRouter} from "v3-periphery/SwapRouter.sol";
+import {ISwapRouter} from "v3-periphery/interfaces/ISwapRouter.sol";
 import {IHandler} from "../interfaces/IHandler.sol";
 import {IHook} from "../interfaces/IHook.sol";
 

--- a/src/handlers/ThrusterSingleTickLiquidityHandlerV2.sol
+++ b/src/handlers/ThrusterSingleTickLiquidityHandlerV2.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 // Interfaces
 import {IThrusterPool} from "../thruster-v3/v3-core/contracts/interfaces/IThrusterPool.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
-import {ISwapRouter} from "v3-periphery/SwapRouter.sol";
+import {ISwapRouter} from "v3-periphery/interfaces/ISwapRouter.sol";
 import {IHandler} from "../interfaces/IHandler.sol";
 import {IHook} from "../interfaces/IHook.sol";
 

--- a/src/handlers/UniswapV3SingleTickLiquidityHandler.sol
+++ b/src/handlers/UniswapV3SingleTickLiquidityHandler.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 // Interfaces
 import {IUniswapV3Pool} from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
-import {ISwapRouter} from "v3-periphery/SwapRouter.sol";
+import {ISwapRouter} from "v3-periphery/interfaces/ISwapRouter.sol";
 import {IHandler} from "../interfaces/IHandler.sol";
 
 // Libraries

--- a/src/handlers/UniswapV3SingleTickLiquidityHandlerV2.sol
+++ b/src/handlers/UniswapV3SingleTickLiquidityHandlerV2.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 // Interfaces
 import {IUniswapV3Pool} from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
-import {ISwapRouter} from "v3-periphery/SwapRouter.sol";
+import {ISwapRouter} from "v3-periphery/interfaces/ISwapRouter.sol";
 import {IHandler} from "../interfaces/IHandler.sol";
 import {IHook} from "../interfaces/IHook.sol";
 

--- a/src/handlers/UniswapV3SingleTickLiquidityHandlerV3.sol
+++ b/src/handlers/UniswapV3SingleTickLiquidityHandlerV3.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 // Interfaces
 import {IUniswapV3Pool} from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
-import {ISwapRouter} from "v3-periphery/SwapRouter.sol";
+import {ISwapRouter} from "v3-periphery/interfaces/ISwapRouter.sol";
 import {IHandler} from "../interfaces/IHandler.sol";
 import {IHook} from "../interfaces/IHook.sol";
 

--- a/src/swapper/SwapRouterSwapper.sol
+++ b/src/swapper/SwapRouterSwapper.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.13;
 
 import {ISwapper} from "../interfaces/ISwapper.sol";
-import {ISwapRouter} from "v3-periphery/SwapRouter.sol";
+import {ISwapRouter} from "v3-periphery/interfaces/ISwapRouter.sol";
 
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/test/amm/BulletXV3Test.t.sol
+++ b/test/amm/BulletXV3Test.t.sol
@@ -8,7 +8,7 @@ import {IBulletXV3Pool} from "../../src/bulletX-v3/v3-core/contracts/interfaces/
 import {TickMath} from "@uniswap/v3-core/contracts/libraries/TickMath.sol";
 import {FixedPoint96} from "@uniswap/v3-core/contracts/libraries/FixedPoint96.sol";
 import {LiquidityAmounts} from "v3-periphery/libraries/LiquidityAmounts.sol";
-import {ISwapRouter} from "v3-periphery/SwapRouter.sol";
+import {ISwapRouter} from "v3-periphery/interfaces/ISwapRouter.sol";
 import {SqrtPriceMath} from "@uniswap/v3-core/contracts/libraries/SqrtPriceMath.sol";
 import {FullMath} from "@uniswap/v3-core/contracts/libraries/FullMath.sol";
 import {SwapMath} from "@uniswap/v3-core/contracts/libraries/SwapMath.sol";

--- a/test/amm/FusionXV3Test.t.sol
+++ b/test/amm/FusionXV3Test.t.sol
@@ -8,7 +8,7 @@ import {IFusionXV3Pool} from "../../src/fusionX-v3/v3-core/contracts/interfaces/
 import {TickMath} from "@uniswap/v3-core/contracts/libraries/TickMath.sol";
 import {FixedPoint96} from "@uniswap/v3-core/contracts/libraries/FixedPoint96.sol";
 import {LiquidityAmounts} from "v3-periphery/libraries/LiquidityAmounts.sol";
-import {ISwapRouter} from "v3-periphery/SwapRouter.sol";
+import {ISwapRouter} from "v3-periphery/interfaces/ISwapRouter.sol";
 import {SqrtPriceMath} from "@uniswap/v3-core/contracts/libraries/SqrtPriceMath.sol";
 import {FullMath} from "@uniswap/v3-core/contracts/libraries/FullMath.sol";
 import {SwapMath} from "@uniswap/v3-core/contracts/libraries/SwapMath.sol";

--- a/test/amm/PancakeV3Test.t.sol
+++ b/test/amm/PancakeV3Test.t.sol
@@ -8,7 +8,7 @@ import {IPancakeV3Pool} from "../../src/pancake-v3/v3-core/contracts/interfaces/
 import {TickMath} from "@uniswap/v3-core/contracts/libraries/TickMath.sol";
 import {FixedPoint96} from "@uniswap/v3-core/contracts/libraries/FixedPoint96.sol";
 import {LiquidityAmounts} from "v3-periphery/libraries/LiquidityAmounts.sol";
-import {ISwapRouter} from "v3-periphery/SwapRouter.sol";
+import {ISwapRouter} from "v3-periphery/interfaces/ISwapRouter.sol";
 import {SqrtPriceMath} from "@uniswap/v3-core/contracts/libraries/SqrtPriceMath.sol";
 import {FullMath} from "@uniswap/v3-core/contracts/libraries/FullMath.sol";
 import {SwapMath} from "@uniswap/v3-core/contracts/libraries/SwapMath.sol";

--- a/test/utils/agni-v3/AgniTestLib.sol
+++ b/test/utils/agni-v3/AgniTestLib.sol
@@ -9,7 +9,7 @@ import {SwapRouter, ISwapRouter} from "v3-periphery/SwapRouter.sol";
 import {TickMath} from "@uniswap/v3-core/contracts/libraries/TickMath.sol";
 import {FixedPoint96} from "@uniswap/v3-core/contracts/libraries/FixedPoint96.sol";
 import {LiquidityAmounts} from "v3-periphery/libraries/LiquidityAmounts.sol";
-import {ISwapRouter} from "v3-periphery/SwapRouter.sol";
+import {ISwapRouter} from "v3-periphery/interfaces/ISwapRouter.sol";
 import {SqrtPriceMath} from "@uniswap/v3-core/contracts/libraries/SqrtPriceMath.sol";
 import {FullMath} from "@uniswap/v3-core/contracts/libraries/FullMath.sol";
 import {SwapMath} from "@uniswap/v3-core/contracts/libraries/SwapMath.sol";

--- a/test/utils/bulletX-v3/BulletXV3TestLib.sol
+++ b/test/utils/bulletX-v3/BulletXV3TestLib.sol
@@ -9,7 +9,7 @@ import {SwapRouter, ISwapRouter} from "v3-periphery/SwapRouter.sol";
 import {TickMath} from "@uniswap/v3-core/contracts/libraries/TickMath.sol";
 import {FixedPoint96} from "@uniswap/v3-core/contracts/libraries/FixedPoint96.sol";
 import {LiquidityAmounts} from "v3-periphery/libraries/LiquidityAmounts.sol";
-import {ISwapRouter} from "v3-periphery/SwapRouter.sol";
+import {ISwapRouter} from "v3-periphery/interfaces/ISwapRouter.sol";
 import {SqrtPriceMath} from "@uniswap/v3-core/contracts/libraries/SqrtPriceMath.sol";
 import {FullMath} from "@uniswap/v3-core/contracts/libraries/FullMath.sol";
 import {SwapMath} from "@uniswap/v3-core/contracts/libraries/SwapMath.sol";

--- a/test/utils/fusionX-v3/FusionXV3TestLib.sol
+++ b/test/utils/fusionX-v3/FusionXV3TestLib.sol
@@ -9,7 +9,7 @@ import {SwapRouter, ISwapRouter} from "v3-periphery/SwapRouter.sol";
 import {TickMath} from "@uniswap/v3-core/contracts/libraries/TickMath.sol";
 import {FixedPoint96} from "@uniswap/v3-core/contracts/libraries/FixedPoint96.sol";
 import {LiquidityAmounts} from "v3-periphery/libraries/LiquidityAmounts.sol";
-import {ISwapRouter} from "v3-periphery/SwapRouter.sol";
+import {ISwapRouter} from "v3-periphery/interfaces/ISwapRouter.sol";
 import {SqrtPriceMath} from "@uniswap/v3-core/contracts/libraries/SqrtPriceMath.sol";
 import {FullMath} from "@uniswap/v3-core/contracts/libraries/FullMath.sol";
 import {SwapMath} from "@uniswap/v3-core/contracts/libraries/SwapMath.sol";

--- a/test/utils/kodiak-v3/KodiakV3TestLib.sol
+++ b/test/utils/kodiak-v3/KodiakV3TestLib.sol
@@ -5,7 +5,7 @@ import "forge-std/Test.sol";
 
 import {IUniswapV3Pool} from "../../../src/kodiak-v3/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
 import {IUniswapV3Factory} from "../../../src/kodiak-v3/v3-core/contracts/interfaces/IUniswapV3Factory.sol";
-import {ISwapRouter} from "v3-periphery/SwapRouter.sol";
+import {ISwapRouter} from "v3-periphery/interfaces/ISwapRouter.sol";
 import {TickMath} from "@uniswap/v3-core/contracts/libraries/TickMath.sol";
 import {FixedPoint96} from "@uniswap/v3-core/contracts/libraries/FixedPoint96.sol";
 import {LiquidityAmounts} from "v3-periphery/libraries/LiquidityAmounts.sol";

--- a/test/utils/pancake-v3/PancakeV3TestLib.sol
+++ b/test/utils/pancake-v3/PancakeV3TestLib.sol
@@ -9,7 +9,7 @@ import {SwapRouter, ISwapRouter} from "v3-periphery/SwapRouter.sol";
 import {TickMath} from "@uniswap/v3-core/contracts/libraries/TickMath.sol";
 import {FixedPoint96} from "@uniswap/v3-core/contracts/libraries/FixedPoint96.sol";
 import {LiquidityAmounts} from "v3-periphery/libraries/LiquidityAmounts.sol";
-import {ISwapRouter} from "v3-periphery/SwapRouter.sol";
+import {ISwapRouter} from "v3-periphery/interfaces/ISwapRouter.sol";
 import {SqrtPriceMath} from "@uniswap/v3-core/contracts/libraries/SqrtPriceMath.sol";
 import {FullMath} from "@uniswap/v3-core/contracts/libraries/FullMath.sol";
 import {SwapMath} from "@uniswap/v3-core/contracts/libraries/SwapMath.sol";

--- a/test/utils/sushi-v3/SushiV3TestLib.sol
+++ b/test/utils/sushi-v3/SushiV3TestLib.sol
@@ -5,7 +5,7 @@ import "forge-std/Test.sol";
 
 import {IUniswapV3Pool} from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
 import {IUniswapV3Factory} from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Factory.sol";
-import {ISwapRouter} from "v3-periphery/SwapRouter.sol";
+import {ISwapRouter} from "v3-periphery/interfaces/ISwapRouter.sol";
 import {TickMath} from "@uniswap/v3-core/contracts/libraries/TickMath.sol";
 import {FixedPoint96} from "@uniswap/v3-core/contracts/libraries/FixedPoint96.sol";
 import {LiquidityAmounts} from "v3-periphery/libraries/LiquidityAmounts.sol";

--- a/test/utils/thruster-v3/ThrusterTestLib.sol
+++ b/test/utils/thruster-v3/ThrusterTestLib.sol
@@ -9,7 +9,7 @@ import {SwapRouter, ISwapRouter} from "v3-periphery/SwapRouter.sol";
 import {TickMath} from "@uniswap/v3-core/contracts/libraries/TickMath.sol";
 import {FixedPoint96} from "@uniswap/v3-core/contracts/libraries/FixedPoint96.sol";
 import {LiquidityAmounts} from "v3-periphery/libraries/LiquidityAmounts.sol";
-import {ISwapRouter} from "v3-periphery/SwapRouter.sol";
+import {ISwapRouter} from "v3-periphery/interfaces/ISwapRouter.sol";
 import {SqrtPriceMath} from "@uniswap/v3-core/contracts/libraries/SqrtPriceMath.sol";
 import {FullMath} from "@uniswap/v3-core/contracts/libraries/FullMath.sol";
 import {SwapMath} from "@uniswap/v3-core/contracts/libraries/SwapMath.sol";


### PR DESCRIPTION
This change makes it possible to compile with newer versions of Solidity as it gets rid of `SwapRouter.sol`'s hard requirement for =0.8.15